### PR TITLE
Use values from headers instead of ONR in whoami function

### DIFF
--- a/frontend/mock/api.json
+++ b/frontend/mock/api.json
@@ -1,6 +1,5 @@
 {
   "whoami": {
-    "oidHenkilo": "1.1.111.111.11.11111111111",
     "etunimet":"Onni Oskari",
     "kutsumanimi": "Onni",
     "sukunimi": "Oppija",

--- a/frontend/src/service/raamitSupport.js
+++ b/frontend/src/service/raamitSupport.js
@@ -14,8 +14,7 @@ window.Service = {
   getUser: () => http.get('whoami')
     .then(v => v.data)
     .then(user => ({
-      name: parseUserName(user),
-      oid: user.oidHenkilo
+      name: parseUserName(user)
     })),
   login: () => { throw new Error('Not implemented') },
   logout: () => { window.location.href = '/shibboleth/Logout?return=/oma-opintopolku/' }


### PR DESCRIPTION
Handler function of `whoami` no longer queries oppijanumerorekisteri
to determine user's identity. Instead, headers received from Shibboleth
are used to construct the object instead.

This changes function contract in the following ways:
- headers `FirstName` and `sn` are now required and their absence triggers
400 Bad Request
- response format changes: attribute `oidHenkilo` is no longer included