### PR TITLE
Ignore an already ignored vulnerability in SNYK configs

### DIFF
--- a/api/auditlog/.snyk
+++ b/api/auditlog/.snyk
@@ -14,6 +14,10 @@ ignore:
     - '*':
         reason: 'not relevant - developer tools only, and we trust developer machines'
         expires: 2019-08-30T08:01:01.564Z
+  'SNYK-JS-CHOWNR-73502':
+    - '*':
+        reason: 'not relevant - developer tools only, and we trust developer machines'
+        expires: 2019-08-30T08:01:01.564Z
   'npm:qs:20170213':
     - '*':
         reason: not relevant - developer tools only

--- a/api/whoami/.snyk
+++ b/api/whoami/.snyk
@@ -14,6 +14,10 @@ ignore:
     - '*':
         reason: 'not relevant - developer tools only, and we trust developer machines'
         expires: 2019-08-30T08:01:01.564Z
+  'SNYK-JS-CHOWNR-73502':
+    - '*':
+        reason: 'not relevant - developer tools only, and we trust developer machines'
+        expires: 2019-08-30T08:01:01.564Z
   'npm:qs:20170213':
     - '*':
         reason: not relevant - developer tools only

--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -14,6 +14,10 @@ ignore:
     - '*':
         reason: 'not relevant - developer tools only, and we trust developer machines'
         expires: 2019-08-30T08:01:01.564Z
+  'SNYK-JS-CHOWNR-73502':
+    - '*':
+        reason: 'not relevant - developer tools only, and we trust developer machines'
+        expires: 2019-08-30T08:01:01.564Z
   'npm:qs:20170213':
     - '*':
         reason: not relevant - developer tools only


### PR DESCRIPTION
SNYK tests are failing because of vulnerability reported here: https://snyk.io/vuln/SNYK-JS-CHOWNR-73502

We're already ignoring it because the issue affects developer tools only, and developer machines are trusted. So this is just an update to SNYK configurations.