### PR TITLE
Korjaa CORS-virheet kun käytetään kielistettyä osoitetta

### DIFF
--- a/frontend/mock/routes.json
+++ b/frontend/mock/routes.json
@@ -1,4 +1,5 @@
 {
+  "/koski/api/omaopintopolkuloki/*": "/$1",
   "/auditlogs/010280-952L": "/auditlogs",
   "/auditlogs/010290-911K": "/auditlogs-huollettava"
 }

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -9,6 +9,7 @@ server.use(jsonServer.bodyParser)
 
 server.use(transformPostRequestToGet)
 server.use(jsonServer.rewriter({
+  "/koski/api/omaopintopolkuloki/*": "/$1",
   "/auditlogs/010280-952L": "/auditlogs",
   "/auditlogs/010290-911K": "/auditlogs-huollettava"
 }))

--- a/frontend/src/component/Log.jsx
+++ b/frontend/src/component/Log.jsx
@@ -53,7 +53,7 @@ Footnotes.propTypes = {
 
 function Log ({ hetu }) {
   return (
-    <Query url={'auditlogs'} method={'post'} body={{ hetu }}>
+    <Query url={'/koski/api/omaopintopolkuloki/auditlogs'} method={'post'} body={{ hetu }}>
       {({ data, error, pending }) => {
         if (error) return <AlertText>{t`Tapahtui odottamaton virhe, emmekä juuri nyt pysty näyttämään tietoja.`}</AlertText>
         if (pending) return <div>{t`Tietoja haetaan`}</div>

--- a/frontend/src/component/generic/widget/StudentInfo.jsx
+++ b/frontend/src/component/generic/widget/StudentInfo.jsx
@@ -54,7 +54,7 @@ const StudentInfo = ({ selectedHetu, onSelectHetu }) => {
 
   return (
     <>
-      <Query url='whoami' onSuccess={data => setData(data)}>
+      <Query url='/koski/api/omaopintopolkuloki/whoami' onSuccess={data => setData(data)}>
         {({ data, error, pending }) => {
           if (error || pending) return null
 

--- a/frontend/src/http/http.js
+++ b/frontend/src/http/http.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import Cookies from 'js-cookie'
 
 const client = axios.create({
-  baseURL: process.env.API_BASE_URL
+  baseURL: window.location.protocol + '//' + window.location.host
 })
 
 const callerId = '1.2.246.562.10.00000000001.oma-opintopolku-loki.frontend'

--- a/frontend/src/service/raamitSupport.js
+++ b/frontend/src/service/raamitSupport.js
@@ -11,7 +11,7 @@ export const parseUserName = user => `${user.etunimet} ${user.sukunimi}`
  * }}
  */
 window.Service = {
-  getUser: () => http.get('whoami')
+  getUser: () => http.get('/koski/api/omaopintopolkuloki/whoami')
     .then(v => v.data)
     .then(user => ({
       name: parseUserName(user)

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -3,10 +3,5 @@ const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.API_BASE_URL': JSON.stringify('https://untuvaopintopolku.fi/koski/api/omaopintopolkuloki/')
-    })
-  ]
+  mode: 'production'
 })

--- a/frontend/webpack.local.js
+++ b/frontend/webpack.local.js
@@ -13,11 +13,11 @@ const raamitProxy = {
 }
 
 const apiProxy = {
-  '/auditlogs': {
+  '/koski/api/omaopintopolkuloki/auditlogs': {
     target: 'http://localhost:3000',
     secure: false
   },
-  '/whoami': {
+  '/koski/api/omaopintopolkuloki/whoami': {
     target: 'http://localhost:3000',
     secure: false
   }
@@ -25,11 +25,6 @@ const apiProxy = {
 
 module.exports = merge(common, {
   mode: 'development',
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.API_BASE_URL': JSON.stringify('http://localhost:3000')
-    })
-  ],
   resolve: {
     alias: {
       Resources: path.resolve(__dirname, 'mock') // dependency-inject mocks to the aliased resources module

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -3,10 +3,5 @@ const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.API_BASE_URL': JSON.stringify('https://opintopolku.fi/koski/api/omaopintopolkuloki/')
-    })
-  ]
+  mode: 'production'
 })

--- a/frontend/webpack.qa.js
+++ b/frontend/webpack.qa.js
@@ -3,10 +3,5 @@ const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.API_BASE_URL': JSON.stringify('https://testiopintopolku.fi/koski/api/omaopintopolkuloki/')
-    })
-  ]
+  mode: 'production'
 })


### PR DESCRIPTION
Esimerkiksi jos opintopolkua käytetään kielistetystä osoitteesta studyinfo.fi