### PR TITLE
chore: update parser dependencies and Maven plugins

### DIFF
--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -243,7 +243,7 @@
 
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>auto-clean</id>
@@ -257,19 +257,19 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.3</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>Create buildversion.txt</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <mkdir dir="${basedir}/target/classes"/>
                 <exec executable="${basedir}/create-buildversion.sh">
                   <arg value="${basedir}/target/classes/buildversion.txt"/>
                   <arg value="${project.version}"/>
                 </exec>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
@@ -281,7 +281,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -305,7 +305,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>4.9.9</version>
         <executions>
           <execution>
             <goals>
@@ -350,7 +350,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>3.5.5</version>
         <configuration>
           <!-- Tests will be run with scalatest-maven-plugin instead -->
           <skipTests>true</skipTests>
@@ -359,7 +359,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>2.2.0</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
@@ -393,7 +393,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>6.5.3</version>
+            <version>12.2.0</version>
             <configuration>
               <suppressionFiles>
                 <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>


### PR DESCRIPTION
## Summary
- Update AWS SDK 1.12.782 → 1.12.797
- Update aws-lambda-java-core 1.2.3 → 1.4.0, events 3.15.0 → 3.16.1
- Update jackson-databind 2.18.2 → 2.18.4
- Update config 1.4.3 → 1.4.6, scala-xml 2.3.0 → 2.4.0
- Update specs2 4.16.1 → 4.23.0
- Update all Maven plugins to latest (incl. antrun tasks→target migration)

### Plugin updates
| Plugin | From | To |
|--------|------|----|
| maven-clean-plugin | 2.4.1 | 3.5.0 |
| maven-antrun-plugin | 1.3 | 3.2.0 |
| maven-shade-plugin | 3.1.1 | 3.6.1 |
| maven-surefire-plugin | 2.21.0 | 3.5.5 |
| scala-maven-plugin | 3.3.2 | 4.9.9 |
| scalatest-maven-plugin | 2.0.0 | 2.2.0 |
| dependency-check-maven | 6.5.3 | 12.2.0 |

## What's NOT included (major/breaking for later)
http4s 0.23→1.0, json4s 4.0→4.1, scala 2.12→2.13/3,
scalamock 5→7, scalatest 3.1→3.2, logstash-logback-encoder 7→9

## Test plan
- [x] `mvn compile` succeeds
- [x] `mvn test-compile` succeeds
- [x] `mvn clean package -DskipTests` produces JAR
- [x] `mvn scalastyle:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)