### PR TITLE
fix: show all organizations and section by usage type

### DIFF
--- a/frontend/src/component/__snapshots__/Log.test.jsx.snap
+++ b/frontend/src/component/__snapshots__/Log.test.jsx.snap
@@ -85,6 +85,11 @@ exports[`Log should render with non-empty log 1`] = `
       Käytetty tietovaranto
     </div>
   </div>,
+  <h3
+    className="typography__H3-sc-1yq3b4j-2 Organizations__SectionTitle-sc-1eh35ye-0 cVeiUL eLrjtW"
+  >
+    Lakiin perustuvat tietojen käyttäjät
+  </h3>,
   <div
     className="Expander__ExpanderContainer-sc-fukmjx-0 fTQBmX"
   >
@@ -216,6 +221,11 @@ exports[`Log should render with non-empty log and language en 1`] = `
       Registry that has been used
     </div>
   </div>,
+  <h3
+    className="typography__H3-sc-1yq3b4j-2 Organizations__SectionTitle-sc-1eh35ye-0 cVeiUL eLrjtW"
+  >
+    Lakiin perustuvat tietojen käyttäjät
+  </h3>,
   <div
     className="Expander__ExpanderContainer-sc-fukmjx-0 fTQBmX"
   >
@@ -347,6 +357,11 @@ exports[`Log should render with non-empty log and language sv 1`] = `
       Använd informationsresurs
     </div>
   </div>,
+  <h3
+    className="typography__H3-sc-1yq3b4j-2 Organizations__SectionTitle-sc-1eh35ye-0 cVeiUL eLrjtW"
+  >
+    Lakiin perustuvat tietojen käyttäjät
+  </h3>,
   <div
     className="Expander__ExpanderContainer-sc-fukmjx-0 fTQBmX"
   >
@@ -478,6 +493,11 @@ exports[`Log should render with non-empty log and organization with no English n
       Registry that has been used
     </div>
   </div>,
+  <h3
+    className="typography__H3-sc-1yq3b4j-2 Organizations__SectionTitle-sc-1eh35ye-0 cVeiUL eLrjtW"
+  >
+    Lakiin perustuvat tietojen käyttäjät
+  </h3>,
   <div
     className="Expander__ExpanderContainer-sc-fukmjx-0 fTQBmX"
   >

--- a/frontend/src/component/organization/Organization.jsx
+++ b/frontend/src/component/organization/Organization.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { lensPath, view } from 'ramda'
 import Expander from 'component/generic/widget/Expander'
 import OrganizationDetails from 'component/organization/OrganizationDetails'
 import LogEntries from 'component/log-entries/LogEntries'
+import t from 'util/translate'
 
-/*
-TODO: Currently we just take the first organization alternative (its name and oid). This must be changed.
- */
-const nameLens = lensPath(['0', 'name'])
-
-const title = organizations => view(nameLens, organizations)
+const title = organizations =>
+  organizations.length > 0
+    ? organizations.map(org => org.name).join(', ')
+    : t('Opintosuorituksista tehdyn jakolinkin tuntematon käyttäjä')
 
 const Organization = ({ organizationAlternatives, timestamps, serviceName, isMyDataUse, isJakolinkkiUse }) => (
   <Expander title={title(organizationAlternatives)} serviceName={serviceName}>

--- a/frontend/src/component/organization/OrganizationDetails.jsx
+++ b/frontend/src/component/organization/OrganizationDetails.jsx
@@ -36,10 +36,10 @@ const weblink = isMyDataUse => (isMyDataUse
   : t('tietosuojaseloste-link')
 )
 
-const OrganizationDetails = ({ isMyDataUse }) => (
+const OrganizationDetails = ({ isMyDataUse, isJakolinkkiUse }) => (
   <Details>
     <Description>
-      <Bold>{t`Tietojen käyttölupa`}:</Bold> {getTranslatedUsagePermissionDescription(isMyDataUse)}
+      <Bold>{t`Tietojen käyttölupa`}:</Bold> {getTranslatedUsagePermissionDescription(isMyDataUse, isJakolinkkiUse)}
     </Description>
 
     <ExternalLink

--- a/frontend/src/component/organization/Organizations.jsx
+++ b/frontend/src/component/organization/Organizations.jsx
@@ -1,34 +1,57 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { lensProp, map, view } from 'ramda'
+import styled from 'styled-components'
 import Organization from 'component/organization/Organization'
 import OrganizationsHeader from 'component/organization/OrganizationsHeader'
+import { H3 } from 'ui/typography'
 
 const oidLens = lensProp('oid')
 
-const Organizations = ({ translatedOrganizations }) => (
-  <React.Fragment>
-    <OrganizationsHeader/>
+const SectionTitle = styled(H3)`
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+`
 
-    {
-      translatedOrganizations.map(({ organizations, timestamps, serviceName, isMyDataUse, isJakolinkkiUse }) => {
-        const key = map(view(oidLens), organizations).join(',')
+const renderOrganization = ({ organizations, timestamps, serviceName, isMyDataUse, isJakolinkkiUse }) => {
+  const key = map(view(oidLens), organizations).join(',') + serviceName + isMyDataUse + isJakolinkkiUse
 
-        return (
-          <Organization
-            key={key}
-            organizationAlternatives={organizations}
-            timestamps={timestamps}
-            serviceName={serviceName}
-            isMyDataUse={isMyDataUse}
-            isJakolinkkiUse={isJakolinkkiUse}
-          />
-        )
-      })
-    }
+  return (
+    <Organization
+      key={key}
+      organizationAlternatives={organizations}
+      timestamps={timestamps}
+      serviceName={serviceName}
+      isMyDataUse={isMyDataUse}
+      isJakolinkkiUse={isJakolinkkiUse}
+    />
+  )
+}
 
-  </React.Fragment>
-)
+const Organizations = ({ translatedOrganizations }) => {
+  const myDataEntries = translatedOrganizations.filter(e => e.isMyDataUse || e.isJakolinkkiUse)
+  const otherEntries = translatedOrganizations.filter(e => !e.isMyDataUse && !e.isJakolinkkiUse)
+
+  return (
+    <React.Fragment>
+      <OrganizationsHeader/>
+
+      {myDataEntries.length > 0 && (
+        <React.Fragment>
+          <SectionTitle>Annetut käyttöluvat</SectionTitle>
+          {myDataEntries.map(renderOrganization)}
+        </React.Fragment>
+      )}
+
+      {otherEntries.length > 0 && (
+        <React.Fragment>
+          <SectionTitle>Lakiin perustuvat tietojen käyttäjät</SectionTitle>
+          {otherEntries.map(renderOrganization)}
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  )
+}
 
 Organizations.propTypes = {
   translatedOrganizations: PropTypes.array.isRequired

--- a/frontend/src/util/usagePermissionDescriptions.js
+++ b/frontend/src/util/usagePermissionDescriptions.js
@@ -1,6 +1,9 @@
 import t from 'util/translate'
 
-export const getTranslatedUsagePermissionDescription = (isMyDataUse) => {
+export const getTranslatedUsagePermissionDescription = (isMyDataUse, isJakolinkkiUse) => {
+  if (isJakolinkkiUse) {
+    return t('Oma opintopolku -palvelussa luomiesi omien opintosuoritusten jakolinkkien käyttökerrat')
+  }
   const permission =
     isMyDataUse
       ? 'Olet antanut tälle palvelutarjoajalle luvan käyttää tietojasi.'


### PR DESCRIPTION
## Summary
- Show all organization names (comma-separated) instead of only the first one (resolves long-standing TODO)
- Show fallback text for entries with empty organizations (jakolinkki anonymous users)
- Use `isJakolinkkiUse` in permission description (was accepted as prop but unused)
- Section the entry list into "Annetut käyttöluvat" (myData + jakolinkki) and "Lakiin perustuvat tietojen käyttäjät"

## Test plan
- [x] `npm run unit` passes (31 tests, 24 snapshots)
- [x] `npm run lint` passes
- [x] Manually verified locally with mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)